### PR TITLE
Revert "RDKEMW-13972 : Fix Thunder plugins interface Activated and Deactivated method implementation"

### DIFF
--- a/plugin/FirmwareUpdate.h
+++ b/plugin/FirmwareUpdate.h
@@ -69,8 +69,8 @@ namespace Plugin {
                 {
                     {
                         LOGINFO("FirmwareUpdate Notification Deactivated");
-                        _parent.Deactivated(connection);
                     }
+                    _parent.Deactivated(connection);
                 }
 
                 void OnUpdateStateChange (const WPEFramework::Exchange::IFirmwareUpdate::State state , const WPEFramework::Exchange::IFirmwareUpdate::SubState substate) override

--- a/plugin/FirmwareUpdate.h
+++ b/plugin/FirmwareUpdate.h
@@ -59,10 +59,12 @@ namespace Plugin {
 
                     void Activated(RPC::IRemoteConnection*) override
                     {
+                        LOGINFO("FirmwareUpdate Notification Activated");
                     }
 
                 void Deactivated(RPC::IRemoteConnection *connection) override
                 {
+                    LOGINFO("FirmwareUpdate Notification Deactivated");
                     _parent.Deactivated(connection);
                 }
 

--- a/plugin/FirmwareUpdate.h
+++ b/plugin/FirmwareUpdate.h
@@ -67,6 +67,7 @@ namespace Plugin {
 
                 void Deactivated(RPC::IRemoteConnection *connection) override
                 {
+                    if(_parent._connectionId == connection->Id())
                     {
                         LOGINFO("FirmwareUpdate Notification Deactivated");
                     }

--- a/plugin/FirmwareUpdate.h
+++ b/plugin/FirmwareUpdate.h
@@ -59,13 +59,18 @@ namespace Plugin {
 
                     void Activated(RPC::IRemoteConnection*) override
                     {
-                        LOGINFO("FirmwareUpdate Notification Activated");
+                        if(_parent._connectionId == connection->Id())
+                        {
+                            LOGINFO("FirmwareUpdate Notification Activated");
+                        }
                     }
 
                 void Deactivated(RPC::IRemoteConnection *connection) override
                 {
-                    LOGINFO("FirmwareUpdate Notification Deactivated");
-                    _parent.Deactivated(connection);
+                    {
+                        LOGINFO("FirmwareUpdate Notification Deactivated");
+                        _parent.Deactivated(connection);
+                    }
                 }
 
                 void OnUpdateStateChange (const WPEFramework::Exchange::IFirmwareUpdate::State state , const WPEFramework::Exchange::IFirmwareUpdate::SubState substate) override

--- a/plugin/FirmwareUpdate.h
+++ b/plugin/FirmwareUpdate.h
@@ -57,7 +57,7 @@ namespace Plugin {
                     INTERFACE_ENTRY(RPC::IRemoteConnection::INotification)
                     END_INTERFACE_MAP
 
-                    void Activated(RPC::IRemoteConnection*) override
+                    void Activated(RPC::IRemoteConnection *connection) override
                     {
                         if(_parent._connectionId == connection->Id())
                         {


### PR DESCRIPTION
Reason For Change: Reduced the logs flood to identify crashed oop plugin
Test procedure : Compile and Verify
version: patch
Priority: P1